### PR TITLE
build: bump up halo2 to `halo2-with-tachyon`

### DIFF
--- a/snark-verifier/Cargo.toml
+++ b/snark-verifier/Cargo.toml
@@ -17,7 +17,7 @@ halo2_curves = { git = "https://github.com/kroma-network/halo2curves", rev = "c0
 rayon = { version = "1.5.3", optional = true }
 
 # system_halo2
-halo2_proofs = { git = "https://github.com/kroma-network/halo2.git", branc = "halo2-with-tachyon", optional = true }
+halo2_proofs = { git = "https://github.com/kroma-network/halo2.git", branch = "halo2-with-tachyon", optional = true }
 
 # loader_evm
 sha3 = { version = "0.10", optional = true }
@@ -31,7 +31,7 @@ rlp = { version = "0.5.2", default-features = false, features = [
 revm = { version = "= 2.3.1", optional = true }
 
 # loader_halo2
-halo2_wrong_ecc = { git = "https://github.com/kroma-network/halo2wrong", rev = "9633f95", package = "ecc", optional = true }
+halo2_wrong_ecc = { git = "https://github.com/kroma-network/halo2wrong", rev = "e8b55cd", package = "ecc", optional = true }
 poseidon = { git = "https://github.com/kroma-network/poseidon", rev = "00a2fe0", optional = true }
 
 [dev-dependencies]
@@ -39,7 +39,7 @@ rand_chacha = "0.3.1"
 paste = "1.0.7"
 
 # system_halo2
-halo2_wrong_ecc = { git = "https://github.com/kroma-network/halo2wrong", rev = "9633f95", package = "ecc" }
+halo2_wrong_ecc = { git = "https://github.com/kroma-network/halo2wrong", rev = "e8b55cd", package = "ecc" }
 
 # loader_evm
 crossterm = { version = "0.25" }


### PR DESCRIPTION
In this PR, halo2 and halo2_wrong deps was updated